### PR TITLE
Define shipped versus planned feature staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ let app = api::router(state)
 
 That's it. Every asset is compiled into the binary via `include_dir!`.
 
+## Shipped vs Planned
+
+This repository keeps both shipped UI code and design exploration in the same tree.
+
+- Shipped features are the ones implemented in `js-src/`, or exposed as documented optional modules under `static/sf/modules/`, and described in the API reference below.
+- Planned or exploratory ideas may appear in CSS or wireframes before the public API is finished. Those should not be treated as supported integration surface until they are wired into a shipped asset and described in the README API reference.
+- When adding new surface area, update the JavaScript API, README, and runnable examples in the same change so the public contract stays explicit.
+
 ## Screenshots
 
 **Planner123** — Gantt chart with split panes, project-colored bars, and constraint scoring:

--- a/WIREFRAME.md
+++ b/WIREFRAME.md
@@ -3,6 +3,11 @@
 Visual reference for every component in the library. Each section shows the
 DOM structure, CSS classes, and how the JS factory wires them together.
 
+Sections in this document follow a simple staging rule:
+
+- Shipped: backed by the current JavaScript API in `js-src/` and safe to document as supported behavior.
+- Planned: useful design or styling direction, but not part of the supported public API yet.
+
 ---
 
 ## 1. Full Page Layout
@@ -268,7 +273,7 @@ Shorthand: `SF.showError(title, detail)`
 
 ---
 
-## 13. Timeline Rail (the hero scheduling view)
+## 13. Timeline Rail (Shipped Core)
 
 ```
   .sf-timeline-header
@@ -387,6 +392,15 @@ gantt.highlightTask('task-1');
 ```
 
 Requires: `/sf/vendor/frappe-gantt/` + `/sf/vendor/split/`
+
+## 15. Planned Rail Extensions
+
+These ideas are intentionally not part of the shipped API surface yet:
+
+- Heatmap strips rendered via `.sf-heatmap` and `.sf-heatmap-segment`
+- Unassigned task pills rendered via `.sf-unassigned-pill`
+
+Treat those as design direction until they are wired into `js-src/13-rail.js` and added to the README API reference.
 
 ---
 


### PR DESCRIPTION
Closes #12.

## Summary
- define a repo-level convention for what counts as shipped versus planned surface
- update README so public examples describe only current supported APIs
- mark wireframe-only rail extensions as planned instead of implying they are already supported
