### PR TITLE
Clarify release workflow messaging and tooling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
-All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
+All notable changes to this project will be documented in this file.
+
+Version tagging is currently automated with `commit-and-tag-version`, but the changelog itself is intended to be a human-readable release summary.
 
 ## 0.1.0 (2026-03-16)

--- a/Makefile
+++ b/Makefile
@@ -158,6 +158,8 @@ ci-local: banner
 	@printf "$(GREEN)$(BOLD)╚══════════════════════════════════════════════════════════╝$(RESET)\n\n"
 
 # ============== Version Management ==============
+# Maintainer note: version bump targets require Node.js + npx because they use
+# commit-and-tag-version. The library runtime path itself remains npm-free.
 
 version:
 	@printf "$(CYAN)Current version:$(RESET) $(YELLOW)$(BOLD)$(VERSION)$(RESET)\n"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 Frontend component library for [SolverForge](https://solverforge.org)
 constraint-optimization applications. Emerald-themed, zero-framework,
-vendor-ready. One line to mount, zero npm, zero webpack.
+vendor-ready. One line to mount, zero npm in the runtime integration path,
+zero webpack.
 
 ```rust
 // Cargo.toml
@@ -484,6 +485,16 @@ make
 # Compile the crate (embeds updated assets)
 cargo build
 ```
+
+## Release Workflow
+
+Consumer integration stays npm-free. Maintainer release automation does not.
+
+- Runtime and application integration use only the bundled static assets and the Rust crate.
+- Version bump targets in `Makefile` currently use `npx commit-and-tag-version`.
+- Release and publish validation otherwise run through Cargo and GitHub Actions.
+
+If you are cutting a release locally, make sure Node.js with `npx` is available before using the `bump-*` targets.
 
 ## Acknowledgments
 


### PR DESCRIPTION
Closes #13.

## Summary
- narrow the README claim so the npm-free story applies to consumer integration, not maintainer release tooling
- document that version bump targets require Node.js and `npx commit-and-tag-version`
- make the changelog framing human-readable instead of treating the release helper as the primary public contract
