### PR TITLE
Add automated package content verification

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -34,3 +34,6 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Verify package contents
+        run: ./scripts/verify-package.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Verify package contents
+        run: ./scripts/verify-package.sh

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -45,5 +45,8 @@ jobs:
       - name: Dry-run publish
         run: cargo publish --dry-run
 
+      - name: Verify package contents
+        run: ./scripts/verify-package.sh
+
       - name: Publish solverforge-ui
         run: cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ JS_SRC  := $(sort $(wildcard js-src/*.js))
 
 # ============== Phony Targets ==============
 .PHONY: banner help assets build build-release test test-quick test-doc test-unit test-one \
-        lint fmt fmt-check clippy ci-local pre-release version \
+        lint fmt fmt-check clippy ci-local pre-release version package-verify \
         bump-patch bump-minor bump-major bump-dry \
         publish-dry publish clean watch
 
@@ -195,8 +195,15 @@ pre-release: banner
 	@cargo test --quiet && printf "$(GREEN)$(CHECK) All tests passed$(RESET)\n"
 	@printf "$(PROGRESS) Dry-run publish...\n"
 	@cargo publish --dry-run 2>&1 | tail -1
+	@printf "$(PROGRESS) Verifying packaged contents...\n"
+	@./scripts/verify-package.sh
 	@printf "$(GREEN)$(CHECK) Package valid$(RESET)\n"
 	@printf "\n$(GREEN)$(BOLD)$(CHECK) Ready for release v$(VERSION)$(RESET)\n\n"
+
+package-verify:
+	@printf "$(PROGRESS) Verifying packaged crate contents...\n"
+	@./scripts/verify-package.sh
+	@printf "$(GREEN)$(CHECK) Package contents verified$(RESET)\n"
 
 # ============== Publishing ==============
 
@@ -206,6 +213,7 @@ publish-dry: test banner
 	@printf "$(CYAN)$(BOLD)╚══════════════════════════════════════════════════════════╝$(RESET)\n\n"
 	@printf "$(GREEN)$(CHECK) All tests passed$(RESET)\n"
 	@cargo publish --dry-run && \
+		./scripts/verify-package.sh && \
 		printf "$(GREEN)$(CHECK) Package valid$(RESET)\n" || \
 		(printf "$(RED)$(CROSS) Package validation failed$(RESET)\n" && exit 1)
 	@printf "\n$(GRAY)Use 'make publish' to publish v$(VERSION) to crates.io$(RESET)\n\n"

--- a/README.md
+++ b/README.md
@@ -500,6 +500,12 @@ Consumer integration stays npm-free. Maintainer release automation does not.
 
 If you are cutting a release locally, make sure Node.js with `npx` is available before using the `bump-*` targets. After the bump completes, push the release commit and tag with `git push --follow-tags` or an equivalent tag-push command so the release automation actually starts.
 
+## Package Verification
+
+Use `make package-verify` to inspect the exact crate contents that would be published.
+
+The verification step checks that required bundled assets and crate metadata are present, and that development-only sources such as `css-src/`, `js-src/`, `scripts/`, and screenshots are not shipped in the published crate.
+
 ## Acknowledgments
 
 solverforge-ui builds on these excellent open-source projects:

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -6,9 +6,27 @@ trap 'rm -f "$manifest"' EXIT
 
 cargo package --allow-dirty --list > "$manifest"
 
+if command -v rg >/dev/null 2>&1; then
+  search_exact() {
+    rg -Fxq "$1" "$manifest"
+  }
+
+  search_prefix() {
+    rg -q "^$1" "$manifest"
+  }
+else
+  search_exact() {
+    grep -Fxq "$1" "$manifest"
+  }
+
+  search_prefix() {
+    grep -Eq "^$1" "$manifest"
+  }
+fi
+
 require() {
   local path="$1"
-  if ! rg -Fxq "$path" "$manifest"; then
+  if ! search_exact "$path"; then
     echo "missing packaged file: $path" >&2
     exit 1
   fi
@@ -16,7 +34,7 @@ require() {
 
 reject_prefix() {
   local prefix="$1"
-  if rg -q "^${prefix}" "$manifest"; then
+  if search_prefix "$prefix"; then
     echo "unexpected packaged path matching prefix: $prefix" >&2
     exit 1
   fi
@@ -24,7 +42,7 @@ reject_prefix() {
 
 reject_exact() {
   local path="$1"
-  if rg -Fxq "$path" "$manifest"; then
+  if search_exact "$path"; then
     echo "unexpected packaged file: $path" >&2
     exit 1
   fi

--- a/scripts/verify-package.sh
+++ b/scripts/verify-package.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+manifest="$(mktemp)"
+trap 'rm -f "$manifest"' EXIT
+
+cargo package --allow-dirty --list > "$manifest"
+
+require() {
+  local path="$1"
+  if ! rg -Fxq "$path" "$manifest"; then
+    echo "missing packaged file: $path" >&2
+    exit 1
+  fi
+}
+
+reject_prefix() {
+  local prefix="$1"
+  if rg -q "^${prefix}" "$manifest"; then
+    echo "unexpected packaged path matching prefix: $prefix" >&2
+    exit 1
+  fi
+}
+
+reject_exact() {
+  local path="$1"
+  if rg -Fxq "$path" "$manifest"; then
+    echo "unexpected packaged file: $path" >&2
+    exit 1
+  fi
+}
+
+require "Cargo.toml"
+require "Cargo.lock"
+require "README.md"
+require "LICENSE"
+require "CHANGELOG.md"
+require "src/lib.rs"
+require "static/sf/sf.css"
+require "static/sf/sf.js"
+require "static/sf/vendor/frappe-gantt/frappe-gantt.min.js"
+require "static/sf/vendor/split/split.min.js"
+require "static/sf/fonts/space-grotesk.woff2"
+require "static/sf/fonts/jetbrains-mono.woff2"
+require "static/sf/img/solverforge-logo.svg"
+
+reject_prefix "css-src/"
+reject_prefix "js-src/"
+reject_prefix "screenshots/"
+reject_prefix "scripts/"
+reject_exact "WIREFRAME.md"
+reject_exact ".versionrc.json"
+
+echo "package contents verified"


### PR DESCRIPTION
Closes #15.

## Summary
- add a repository-owned package verification script based on `cargo package --list`
- fail CI and publish workflows if required packaged files are missing or excluded files leak into the crate
- expose the check locally via `make package-verify` and include it in the pre-release path
- document the verification workflow in the README
