### PR TITLE
Harden GitHub workflows against action supply-chain risk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,21 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        run: |
+          rm -rf .git
+          git init .
+          git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          git fetch --depth=1 origin "${{ github.sha }}"
+          git checkout --detach FETCH_HEAD
 
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Verify assets are up to date
         run: |

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -14,21 +14,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        run: |
+          rm -rf .git
+          git init .
+          git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          git fetch --depth=1 origin "${{ github.sha }}"
+          git checkout --detach FETCH_HEAD
 
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,21 +22,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        run: |
+          rm -rf .git
+          git init .
+          git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          git fetch --depth=1 origin "${{ github.sha }}"
+          git checkout --detach FETCH_HEAD
 
       - name: Install Rust
         run: |
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-
-      - name: Cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Check formatting
         run: cargo fmt --all -- --check
@@ -58,9 +55,14 @@ jobs:
     needs: [test]
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
+      - name: Checkout repository
+        run: |
+          rm -rf .git
+          git init .
+          git remote add origin "https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          git fetch --force --tags origin "+refs/heads/*:refs/remotes/origin/*"
+          git fetch --force origin "${{ github.sha }}"
+          git checkout --detach FETCH_HEAD
 
       - name: Get version
         id: version
@@ -89,19 +91,32 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          name: v${{ steps.version.outputs.version }}
-          body: |
-            ## What's Changed
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          cat <<'EOF' > release-notes.md
+          ## What's Changed
 
-            ${{ steps.changelog.outputs.changelog }}
+          ${{ steps.changelog.outputs.changelog }}
 
-            ## Installation
+          ## Installation
 
-            ```toml
-            [dependencies]
-            solverforge-ui = "${{ steps.version.outputs.version }}"
-            ```
-          draft: false
-          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          ```toml
+          [dependencies]
+          solverforge-ui = "${{ steps.version.outputs.version }}"
+          ```
+          EOF
+
+          release_args=(
+            "v${{ steps.version.outputs.version }}"
+            --target "${{ github.sha }}"
+            --title "v${{ steps.version.outputs.version }}"
+            --notes-file release-notes.md
+            --verify-tag
+          )
+
+          if [[ "${{ steps.version.outputs.version }}" == *-* ]]; then
+            release_args+=(--prerelease)
+          fi
+
+          gh release create "${release_args[@]}"


### PR DESCRIPTION
### Motivation

- The workflows referenced mutable third‑party GitHub Action tags (e.g. `actions/checkout@v4`, `actions/cache@v4`, `softprops/action-gh-release@v1`), creating a supply‑chain risk that could exfiltrate CI secrets such as `CARGO_REGISTRY_TOKEN`.
- The goal is a minimal, workflow-only remediation to remove mutable `uses:` references while preserving CI/build/publish behavior.

### Description

- Replaced `uses: actions/checkout@...` steps in `ci.yml`, `publish-crates.yml`, and `release.yml` with explicit shell-based checkout steps using `git` and the `github.token` to avoid relying on mutable action tags.
- Removed the `actions/cache@v4` cache steps from the workflows to eliminate another unpinned third‑party action dependency.
- Replaced `softprops/action-gh-release@v1` with a `gh release create` shell step (using `GITHUB_TOKEN`) that preserves release notes and prerelease handling without invoking an unpinned external action.
- Files modified: ` .github/workflows/ci.yml`, `.github/workflows/publish-crates.yml`, and `.github/workflows/release.yml`.

### Testing

- Ran `rg -n "uses:" .github/workflows` to verify the unpinned `uses:` references were removed and this check passed.
- Validated workflow YAML by loading each file with `ruby -e 'YAML.load_file(...)'` and this succeeded for all modified files.
- Ran `git diff --check` to ensure there were no whitespace or git-diff issues and it returned clean.
- Ran `cargo test` and the test suite completed successfully (0 tests; all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc86ef8d4833189ba8cfe31c3167e)