### PR TITLE
Harden Forgejo CI: disable untrusted PR runs on self-hosted runner

### DIFF
--- a/.forgejo/workflows/ci.yml
+++ b/.forgejo/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches: [main, dev, release/*, feature/*]
-  pull_request:
-    branches: [main, dev, release/*]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
### Motivation
- The CI workflow ran on `pull_request` and executed repository-controlled build steps on the self-hosted `rust` runner, allowing untrusted PRs to run arbitrary commands on the runner host, so the trigger must be removed to prevent RCE risk.

### Description
- Replace the `pull_request` trigger with `workflow_dispatch` in `.forgejo/workflows/ci.yml` while keeping the existing `push` triggers and all job steps intact to preserve CI functionality for trusted pushes and manual runs.

### Testing
- Validated the edited workflow parses successfully with `ruby -e "require 'yaml'; YAML.load_file('.forgejo/workflows/ci.yml')"` which returned successfully; `git diff` showed the change; and the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc869ba90833185831906444628c5)