### PR TITLE
Harden GitHub workflows against action supply-chain risk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,4 +119,8 @@ jobs:
             release_args+=(--prerelease)
           fi
 
-          gh release create "${release_args[@]}"
+          if gh release view "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            gh release edit "${release_args[@]}"
+          else
+            gh release create "${release_args[@]}"
+          fi


### PR DESCRIPTION
### Motivation

- The workflows referenced mutable third‑party GitHub Action tags (e.g. `actions/checkout@v4`, `actions/cache@v4`, `softprops/action-gh-release@v1`), creating a supply‑chain risk that could exfiltrate CI secrets such as `CARGO_REGISTRY_TOKEN`.
- The goal is a minimal, workflow-only remediation to remove mutable `uses:` references while preserving CI/build/publish behavior.

### Description

- Replaced `uses: actions/checkout@...` steps in `ci.yml`, `publish-crates.yml`, and `release.yml` with explicit shell-based checkout steps using `git` and the `github.token` to avoid relying on mutable action tags.
- Removed the `actions/cache@v4` cache steps from the workflows to eliminate another unpinned third‑party action dependency.
- Replaced `softprops/action-gh-release@v1` with a `gh release create` shell step (using `GITHUB_TOKEN`) that preserves release notes and prerelease handling without invoking an unpinned external action.
- Files modified: ` .github/workflows/ci.yml`, `.github/workflows/publish-crates.yml`, and `.github/workflows/release.yml`.

### Testing

- Ran `rg -n "uses:" .github/workflows` to verify the unpinned `uses:` references were removed and this check passed.
- Validated workflow YAML by loading each file with `ruby -e 'YAML.load_file(...)'` and this succeeded for all modified files.
- Ran `git diff --check` to ensure there were no whitespace or git-diff issues and it returned clean.
- Ran `cargo test` and the test suite completed successfully (0 tests; all checks passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc86ef8d4833189ba8cfe31c3167e)