### PR TITLE
Use Tailwind emerald color for SolverForge make banner text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 
 # ============== Colors & Symbols ==============
 GREEN := \033[92m
+EMERALD := \033[38;2;16;185;129m
 CYAN := \033[96m
 YELLOW := \033[93m
 MAGENTA := \033[95m
@@ -38,8 +39,8 @@ VERSIONED_JS := static/sf/sf.$(VERSION).js
 
 # ============== Banner ==============
 banner:
-	@printf "$(CYAN)$(BOLD)  SolverForge UI$(RESET)\n"
-	@printf "  $(GRAY)v$(VERSION)$(RESET) $(CYAN)Component Library$(RESET)\n\n"
+	@printf "$(EMERALD)$(BOLD)  SolverForge UI$(RESET)\n"
+	@printf "  $(GRAY)v$(VERSION)$(RESET) $(EMERALD)Component Library$(RESET)\n\n"
 
 # ============== Asset Targets ==============
 


### PR DESCRIPTION
### Motivation
- Align the terminal banner with the project's emerald brand by using the Tailwind `emerald-500` color for the Makefile banner text.

### Description
- Add an `EMERALD` ANSI truecolor constant set to the Tailwind `emerald-500` hex `#10b981` in `Makefile` as `EMERALD := \033[38;2;16;185;129m`.
- Update the `banner` target in `Makefile` so `SolverForge UI` and the accompanying `Component Library` label print using the `EMERALD` color escape sequence.

### Testing
- Ran `make banner` and confirmed the banner prints with the updated emerald color escape sequence (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cfdad9ee1883319f9c1caf4dd206be)