### PR TITLE
[codex] Keep browser smoke screenshots out of tracked baselines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ VERSIONED_JS := static/sf/sf.$(VERSION).js
 
 # ============== Phony Targets ==============
 .PHONY: banner help assets build build-release test test-quick test-doc test-unit test-frontend test-browser test-one \
-        lint lint-frontend fmt fmt-check clippy ci-local pre-release version package-verify browser-setup \
+        lint lint-frontend fmt fmt-check clippy ci-local pre-release version package-verify browser-setup screenshots-update \
         bump-version bump-patch bump-minor bump-major bump-dry release-tag demo-serve \
         publish-dry publish clean watch
 
@@ -135,6 +135,12 @@ test-browser:
 	@node tests/demo-browser-check.js && \
 		printf "$(GREEN)$(CHECK) Browser smoke tests passed$(RESET)\n" || \
 		(printf "$(RED)$(CROSS) Browser smoke tests failed$(RESET)\n" && exit 1)
+
+screenshots-update:
+	@printf "$(PROGRESS) Refreshing tracked browser screenshot baselines...\n"
+	@node tests/demo-browser-check.js --update-screenshots && \
+		printf "$(GREEN)$(CHECK) Screenshot baselines refreshed$(RESET)\n" || \
+		(printf "$(RED)$(CROSS) Screenshot baseline refresh failed$(RESET)\n" && exit 1)
 
 lint-frontend:
 	@printf "$(PROGRESS) Running frontend lint...\n"
@@ -345,6 +351,7 @@ help: banner
 	@/bin/echo -e "  $(GREEN)make test-frontend$(RESET)  - Run frontend Node tests"
 	@/bin/echo -e "  $(GREEN)make test-browser$(RESET)   - Run browser demo smoke tests"
 	@/bin/echo -e "  $(GREEN)make test-one TEST=name$(RESET) - Run specific test with output"
+	@/bin/echo -e "  $(GREEN)make screenshots-update$(RESET) - Refresh tracked browser screenshot baselines"
 	@/bin/echo -e ""
 	@/bin/echo -e "$(CYAN)$(BOLD)Lint & Format:$(RESET)"
 	@/bin/echo -e "  $(GREEN)make lint$(RESET)           - Run fmt-check + clippy + frontend lint"

--- a/README.md
+++ b/README.md
@@ -799,7 +799,8 @@ Runnable demo fixtures live in `demos/`.
 - `demos/timeline-dense.html` is the repeatable 28-day, 100-lane, 1500-item dense validation fixture for one scrollable body viewport.
 - `demos/rail.html` focuses on the low-level rail primitives: resource cards, blocks, gauges, and changeovers.
 - `make demo-serve` serves the repository at `http://localhost:8000/demos/` for local validation.
-- `make test-browser` runs browser-level smoke tests against the shipped demo fixtures and refreshes the timeline acceptance screenshots in `screenshots/`.
+- `make test-browser` runs browser-level smoke tests against the shipped demo fixtures and writes transient screenshots to `target/browser-smoke/screenshots/`.
+- `make screenshots-update` explicitly refreshes the tracked timeline acceptance screenshots in `screenshots/`.
 - Run `make browser-setup` once on a machine to install the Playwright test dependency and Chromium.
 
 ## Acknowledgments

--- a/demos/README.md
+++ b/demos/README.md
@@ -33,6 +33,13 @@ make test-browser
 ```
 
 The automated check serves the repository locally, opens the runnable demo fixtures in Chromium, fails on page or script errors, and verifies that the primary shipped UI surfaces mount successfully.
+It writes transient screenshots to `target/browser-smoke/screenshots/` by default so ordinary validation does not modify tracked baselines.
+
+Refresh the tracked timeline screenshot baselines only when accepting an intentional visual change:
+
+```bash
+make screenshots-update
+```
 
 ## Coverage
 

--- a/tests/demo-browser-check.js
+++ b/tests/demo-browser-check.js
@@ -4,7 +4,46 @@ const http = require('node:http');
 const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
-const SCREENSHOT_DIR = path.join(ROOT, 'screenshots');
+const SCREENSHOT_BASELINE_DIR = path.join(ROOT, 'screenshots');
+const SCREENSHOT_ARTIFACT_DIR = path.join(ROOT, 'target', 'browser-smoke', 'screenshots');
+
+function usage() {
+  return 'Usage: node tests/demo-browser-check.js [--update-screenshots]';
+}
+
+function parseRunnerConfig(args) {
+  if (args.length === 0) {
+    return {
+      screenshotDir: SCREENSHOT_ARTIFACT_DIR,
+      updateScreenshots: false,
+    };
+  }
+
+  if (args.length === 1 && args[0] === '--update-screenshots') {
+    return {
+      screenshotDir: SCREENSHOT_BASELINE_DIR,
+      updateScreenshots: true,
+    };
+  }
+
+  throw new Error('Unknown browser check option: ' + args.join(' ') + '\n' + usage());
+}
+
+function prepareScreenshotDirectory(config) {
+  if (!config.updateScreenshots) {
+    fs.rmSync(config.screenshotDir, { recursive: true, force: true });
+  }
+  fs.mkdirSync(config.screenshotDir, { recursive: true });
+}
+
+let runnerConfig;
+try {
+  runnerConfig = parseRunnerConfig(process.argv.slice(2));
+  prepareScreenshotDirectory(runnerConfig);
+} catch (error) {
+  process.stderr.write((error && error.message ? error.message : String(error)) + '\n');
+  process.exit(1);
+}
 
 function contentTypeFor(filePath) {
   switch (path.extname(filePath).toLowerCase()) {
@@ -147,8 +186,7 @@ async function runCheck(name, fn) {
 }
 
 async function captureScreenshot(target, filename) {
-  fs.mkdirSync(SCREENSHOT_DIR, { recursive: true });
-  const screenshotPath = path.join(SCREENSHOT_DIR, filename);
+  const screenshotPath = path.join(runnerConfig.screenshotDir, filename);
   await target.screenshot({ path: screenshotPath });
   assert.equal(fs.existsSync(screenshotPath), true);
   assert.equal(fs.statSync(screenshotPath).size > 0, true);


### PR DESCRIPTION
## Summary
- route default browser smoke screenshots to `target/browser-smoke/screenshots/` instead of tracked `screenshots/`
- add `make screenshots-update` and `--update-screenshots` for intentional baseline refreshes
- update README and demo docs to document the split workflow

## Context
Fixes #46. Related to #45.

This is the separate browser-test workflow fix discussed while reviewing @benabel's TypeScript PR, so #45 can drop the pre-push screenshot reset workaround and stay focused on type-checking.

## Validation
- `make test-browser`
- `node tests/demo-browser-check.js --bad-option`
- `make test-frontend`
- `make lint-frontend`
- `make -n screenshots-update`
- `make ci-local`

Note: I did not run full `make screenshots-update` because this environment currently regenerates `rail-timeline-narrow.png` differently, and that command would intentionally update a tracked baseline outside this fix.